### PR TITLE
Add proper sql_parse_json tests and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ SELECT * FROM parse_columns('SELECT 1 AS num, ''hello'' AS str', 0);
 │         0 │ num      │ INTEGER  │
 │         1 │ str      │ VARCHAR  │
 └───────────┴──────────┴──────────┘
+
+-- Get full query plan as JSON
+SELECT sql_parse_json('SELECT 1 + 2 AS result');
+-- Returns:
+-- {
+--   "error": false,
+--   "plans": [{
+--     "type": "LOGICAL_PROJECTION",
+--     "expressions": [{
+--       "alias": "result",
+--       "name": "+",
+--       "return_type": {"id": "INTEGER"},
+--       "children": [...]
+--     }],
+--     "children": [{"type": "LOGICAL_DUMMY_SCAN"}]
+--   }]
+-- }
+
+-- Extract specific info from query plan
+SELECT json_extract_string(sql_parse_json('SELECT 1 + 2 AS x'), '$.plans[0].expressions[0].alias');
+-- Returns: x
 ```
 
 ## Building

--- a/test/sql/parser.test
+++ b/test/sql/parser.test
@@ -150,13 +150,39 @@ SELECT parse_function_names('SELECT 1')
 # sql_parse_json(query) -> VARCHAR (JSON)
 # -----------------------------------------------------------------------------
 
-query I
+# Valid query returns error=false
+query T
 SELECT json_extract_string(sql_parse_json('SELECT 1'), '$.error')
 ----
 false
 
+# Can extract plan type
+query T
+SELECT json_extract_string(sql_parse_json('SELECT 1'), '$.plans[0].type')
+----
+LOGICAL_PROJECTION
+
+# Can extract expression info
+query T
+SELECT json_extract_string(sql_parse_json('SELECT 1 + 2 AS result'), '$.plans[0].expressions[0].alias')
+----
+result
+
+# Can extract function name from expression
+query T
+SELECT json_extract_string(sql_parse_json('SELECT 1 + 2'), '$.plans[0].expressions[0].name')
+----
++
+
+# Invalid query returns error=true
+query T
+SELECT json_extract_string(sql_parse_json('INVALID SQL'), '$.error')
+----
+true
+
+# Invalid query includes error message
 query I
-SELECT sql_parse_json('INVALID') LIKE '%error%'
+SELECT json_extract_string(sql_parse_json('INVALID SQL'), '$.error_message') LIKE '%syntax error%'
 ----
 true
 


### PR DESCRIPTION
Tests for extracting plan type, expression alias, function name, and error messages from JSON output.